### PR TITLE
Fix wrong suffix links of CDAWG

### DIFF
--- a/src/cdawg.ts
+++ b/src/cdawg.ts
@@ -358,7 +358,7 @@ class CDAWG {
       this.ap = this.move_trust(
         this.ap.parent.slink,
         this.text,
-        edge_beg + 1,
+        edge_beg,
         match_len,
       )
     }


### PR DESCRIPTION
Fix the bug reported in https://github.com/kg86/visds/issues/39.