### PR TITLE
Fix CDAWG construction

### DIFF
--- a/src/cdawg.ts
+++ b/src/cdawg.ts
@@ -347,6 +347,10 @@ class CDAWG {
     } else {
       this.sink.slink = this.sink;
     }
+    // if the active point is at the end of the edge, move to the next node.
+    if (this.ap.edge.len === this.ap.match_len) {
+      this.ap = new State(this.ap.edge.child);
+    }
     console.log("insert end, ap is", this.ap);
   }
 


### PR DESCRIPTION
# Overview

I found a bug in the code for the CDAWG construction.
The current code does not update the active point of the CDAWG when it reaches the end of an edge.
This pull request is intended to fix that issue.

## Before and After Examples:

**before**
![before fix](https://github.com/kg86/visds/assets/28044202/45a82a94-8c77-45f9-b945-cc905646484a)

after:
![After fix](https://github.com/kg86/visds/assets/28044202/73f95560-fc67-412c-a4c7-cc7c52a8697b)

Other examples include cases where the output was incorrect when the string was `abaac` or `acaa`.
My PR also fixes the above cases.

