### PR TITLE
Add Linear Size CDAWG

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,6 @@
 - [Directed Acyclic Word Graph (DAWG)](https://kg86.github.io/visds/dist/vis_dawg.html)
 - [Compact Directed Acyclic Word Graph (CDAWG)](https://kg86.github.io/visds/dist/vis_cdawg.html)
 - [Linear Size Suffix Trie](https://kg86.github.io/visds/dist/vis_lstrie.html)
+- [Linear Size CDAWG](https://kg86.github.io/visds/dist/vis_lscdawg.html)
 - [Suffix Array](https://kg86.github.io/visds/dist/vis_sa.html)
 - [LCP Array](https://kg86.github.io/visds/dist/vis_lcp.html)

--- a/dist/vis_lscdawg.html
+++ b/dist/vis_lscdawg.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-CHP991L8GM"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-CHP991L8GM');
+    </script>
+    <meta charset="UTF-8" />
+    <meta http-equiv="Cache-Control" content="no-cache" />
+
+    <title>Visualization of Linear Size CDAWG</title>
+
+    <link rel="stylesheet" type="text/css" href="./my.css" />
+    <link rel="stylesheet" type="text/css" href="./vis-network.min.css" />
+  </head>
+
+  <body>
+    <h2>Visualization of Linear Size CDAWG</h2>
+
+    <input id="input_text" type="text" value="cocoa" style="font-size:32px;" />
+    <br />
+    Show Suffix Links:
+    <input id="show_suffix_links" type="checkbox" checked />
+    <br />
+    Show Extended Suffix Links:
+    <input id="show_extended_suffix_links" type="checkbox" checked />
+    <br />
+
+    <div id="network"></div>
+
+    <p id="selection"></p>
+
+    <div style="width: 600px; margin: auto;">
+      <h2>Links</h2>
+      <ul style="list-style-type: disc; text-align: left;">
+        <li>
+          <a
+            href="https://www.researchgate.net/publication/319485678"
+            >Paper of Linear Size CDAWG
+          </a>
+        </li>
+        <li>
+          <a href="https://kg86.github.io/visds/">Data Structure Visualizer</a>
+        </li>
+      </ul>
+    </div>
+    <script type="text/javascript" src="./vis_lscdawg.js"></script>
+  </body>
+</html>

--- a/src/lscdawg.ts
+++ b/src/lscdawg.ts
@@ -10,14 +10,12 @@ class CNode {
   slink: CNode;
   is_explicit: boolean;
   out_edges: Map<string, Edge>;
-  in_edges: Array<Edge>;
   constructor(value: number, birth_time: number, is_explicit: boolean) {
     this.value = value;
     this.birth_time = birth_time;
     this.slink = this;
     this.is_explicit = is_explicit;
     this.out_edges = new Map();
-    this.in_edges = [];
   }
 }
 
@@ -84,12 +82,20 @@ class LSCDAWG {
 
       for (const lst_child of lst_node.children.values()) {
         const cdawg_child = lst_node_correspondence[lst_child.birth_time]!;
-        const edge = new Edge(lst_child.birth_time, lst_child.in_edge_label, cdawg_node, cdawg_child);
-        this.edges.push(edge);
-        cdawg_node.out_edges.set(lst_child.in_edge_label, edge);
-        cdawg_child.in_edges.push(edge);
+        if (!cdawg_node.out_edges.has(lst_child.in_edge_label)) {
+          const edge = new Edge(lst_child.birth_time, lst_child.in_edge_label, cdawg_node, cdawg_child);
+          this.edges.push(edge);
+          cdawg_node.out_edges.set(lst_child.in_edge_label, edge);
+        }
       }
     }
+
+    for(const node of this.nodes) {
+      if (node.is_explicit) {
+        node.value = num_explicit_nodes - node.value - 1;
+      }
+    }
+
     this.root = lst_node_correspondence[lstrie.root.birth_time]!;
 
     console.log(Array.from(lstrie.slinks.entries()));
@@ -114,8 +120,6 @@ class LSCDAWG {
           label: node.is_explicit ? node.value.toString() : "",
           id: json_node_id,
           level: -1,
-          // level: use_depth ? depth : height - node.height,
-          // shape: node.is_leaf ? "box" : "circle",
           color: {
             border: node.is_explicit ? "#2B7CE9" : "#000000",
             background: node.is_explicit ? "#D2E5FF" : "#000000",

--- a/src/lscdawg.ts
+++ b/src/lscdawg.ts
@@ -1,8 +1,5 @@
 // Linear-size CDAWG
-import { LargeNumberLike } from "crypto";
 import { build_lstrie, StrTree } from "./lstrie";
-
-type ElementType<T> = T extends (infer U)[] ? U : never;
 
 class CNode {
   birth_time: number;
@@ -42,18 +39,14 @@ class Edge {
 }
 
 class LSCDAWG {
-  lstrie: StrTree;
   root: CNode;
   nodes: Array<CNode>;
   edges: Array<Edge>;
 
-  // build this from CDAWG
+  // obtain a lscdawg by merging isomorphics subtrees of the lstrie
   constructor(lstrie: StrTree) {
-    // obtain a lscdawg by merging isomorphics subtrees of the lstrie
-    
     this.nodes = [];
     this.edges = [];
-    this.lstrie = lstrie;
 
     const cdawg_node_map = new Map<string, CNode>();
     const lst_node_correspondence = new Array<CNode | undefined>(lstrie.nodes.length);
@@ -201,7 +194,6 @@ class LSCDAWG {
     }
     console.log("json_nodes", json_nodes.length, "json_edges", json_edges.length);
     return { nodes: json_nodes, edges: json_edges };
-    // return this.lstrie?.json;
   }
 }
 

--- a/src/lscdawg.ts
+++ b/src/lscdawg.ts
@@ -1,0 +1,221 @@
+// Linear-size CDAWG
+import { LargeNumberLike } from "crypto";
+import { build_lstrie, StrTree } from "./lstrie";
+
+type ElementType<T> = T extends (infer U)[] ? U : never;
+
+class CNode {
+  birth_time: number;
+  value: number; // value is only used for vertex label
+  slink: CNode;
+  is_explicit: boolean;
+  out_edges: Map<string, Edge>;
+  in_edges: Array<Edge>;
+  constructor(value: number, birth_time: number, is_explicit: boolean) {
+    this.value = value;
+    this.birth_time = birth_time;
+    this.slink = this;
+    this.is_explicit = is_explicit;
+    this.out_edges = new Map();
+    this.in_edges = [];
+  }
+}
+
+class EdgeIdentifier {
+  text: string;
+  child_birth: number;
+  constructor(text: string, child_birth: number) {
+    this.text = text;
+    this.child_birth = child_birth;
+  }
+}
+
+class Edge {
+  birth_time: number;
+  text: string;
+  parent: CNode;
+  child: CNode;
+  constructor(birth_time: number, text: string, parent: CNode, child: CNode) {
+    this.birth_time = birth_time;
+    this.text = text;
+    this.parent = parent;
+    this.child = child;
+  }
+}
+
+class LSCDAWG {
+  lstrie: StrTree;
+  root: CNode;
+  nodes: Array<CNode>;
+  edges: Array<Edge>;
+
+  // build this from CDAWG
+  constructor(lstrie: StrTree) {
+    // obtain a lscdawg by merging isomorphics subtrees of the lstrie
+    
+    this.nodes = [];
+    this.edges = [];
+    this.lstrie = lstrie;
+
+    const cdawg_node_map = new Map<string, CNode>();
+    const lst_node_correspondence = new Array<CNode | undefined>(lstrie.nodes.length);
+
+    const lst_nodes = lstrie.nodes;
+    lst_nodes.sort((a, b) => a.height - b.height);
+    let num_explicit_nodes = 0;
+
+    for (const lst_node of lst_nodes) {
+      const edge_identifiers = new Array<EdgeIdentifier>();
+      for (const child of lst_node.children.values()) {
+        const child_node = lst_node_correspondence[child.birth_time]!;
+        edge_identifiers.push(new EdgeIdentifier(child.in_edge_label, child_node.birth_time));
+      }
+      edge_identifiers.sort((a, b) => a.text.localeCompare(b.text));
+      const key = JSON.stringify([edge_identifiers, lst_node.is_explicit]);
+      let cdawg_node = cdawg_node_map.get(key);
+      if (cdawg_node === undefined) {
+        cdawg_node = new CNode(num_explicit_nodes, this.nodes.length, lst_node.is_explicit);
+        if(lst_node.is_explicit) num_explicit_nodes++;
+        cdawg_node_map.set(key, cdawg_node);
+        this.nodes.push(cdawg_node);
+      }
+      cdawg_node.is_explicit ||= lst_node.is_explicit;
+      lst_node_correspondence[lst_node.birth_time] = cdawg_node;
+
+      for (const lst_child of lst_node.children.values()) {
+        const cdawg_child = lst_node_correspondence[lst_child.birth_time]!;
+        const edge = new Edge(lst_child.birth_time, lst_child.in_edge_label, cdawg_node, cdawg_child);
+        this.edges.push(edge);
+        cdawg_node.out_edges.set(lst_child.in_edge_label, edge);
+        cdawg_child.in_edges.push(edge);
+      }
+    }
+    this.root = lst_node_correspondence[lstrie.root.birth_time]!;
+
+    console.log(Array.from(lstrie.slinks.entries()));
+    for (const [from_node, to_node] of Array.from(lstrie.slinks.entries()).concat(
+      Array.from(lstrie.elinks.entries())
+    )) {
+      const from = lst_node_correspondence[from_node.birth_time];
+      const to = lst_node_correspondence[to_node.birth_time];
+      from!.slink = to!;
+    }
+  }
+  get json() {
+    const json_nodes: any = [];
+    const json_edges: any = [];
+    const cdawg_node_to_json_node = new Map<CNode, number>();
+
+    // create nodes
+    const get_json_node = (node: CNode): number => {
+      if (!cdawg_node_to_json_node.has(node)) {
+        const json_node_id = json_nodes.length;
+        const ndic = {
+          label: node.is_explicit ? node.value.toString() : "",
+          id: json_node_id,
+          level: -1,
+          // level: use_depth ? depth : height - node.height,
+          // shape: node.is_leaf ? "box" : "circle",
+          color: {
+            border: node.is_explicit ? "#2B7CE9" : "#000000",
+            background: node.is_explicit ? "#D2E5FF" : "#000000",
+          },
+        }
+        json_nodes.push(ndic);
+        cdawg_node_to_json_node.set(node, json_node_id);
+      }
+      return cdawg_node_to_json_node.get(node)!;
+    }
+    this.nodes?.forEach(get_json_node);
+
+    // set edge level
+    const set_level_rec = (node: CNode, level: number) => {
+      const n = json_nodes[cdawg_node_to_json_node.get(node)!];
+      if (n.level < level) {
+        n.level = level;
+        node.out_edges.forEach((edge) => {
+          set_level_rec(edge.child, n.level + 1);
+        });
+      }
+    };
+    set_level_rec(this.root, 0);
+
+    // set edge roundness
+    const max_roundness = 0.5;
+    const min_roundness = -0.5;
+    const roundness = (edge: Edge) => {
+      const ebirth = Array.from(edge.parent.out_edges.values()).map((e) => [
+        e.birth_time,
+        e,
+      ]);
+      ebirth.sort();
+      let birth_idx = -1;
+      for (let i = 0; i < ebirth.length; i++) {
+        if (ebirth[i][1] === edge) {
+          birth_idx = i;
+        }
+      }
+      if (edge.parent.out_edges.size === 1) return 0.0;
+      else
+        return (
+          min_roundness +
+          ((max_roundness - min_roundness) * birth_idx) /
+            (edge.parent.out_edges.size - 1)
+        );
+    };
+
+    // create edges
+    for (const edge of this.edges) {
+      const from = get_json_node(edge.parent);
+      const to = get_json_node(edge.child);
+      const edge_dic = {
+        from: from,
+        to: to,
+        id: from + "->" + to + " (" + edge.text + ")",
+        label: edge.text,
+        font: { align: "top" },
+        color: {
+          color: "#2B7CE9",
+        },
+        smooth: { type: "curvedCW", roundness: roundness(edge) },
+      };
+      json_edges.push(edge_dic);
+    }
+    // create slinks
+    for(const node of this.nodes) {
+      const slink_node = node.slink;
+      if(slink_node === node) continue;
+      const slink_dic = {
+        from: get_json_node(node),
+        to: get_json_node(slink_node),
+        id: get_json_node(node) + "~>" + get_json_node(slink_node),
+        dashes: true,
+        color: { color: node.is_explicit ? "#848484" : "#ff0000" },
+        smooth: { type: "curvedCW", roundness: 0.4 },
+      };
+      json_edges.push(slink_dic);
+    }
+    console.log("json_nodes", json_nodes.length, "json_edges", json_edges.length);
+    return { nodes: json_nodes, edges: json_edges };
+    // return this.lstrie?.json;
+  }
+}
+
+export const build_lscdawg = (
+    text: string,
+    show_suffix_links: boolean,
+    show_extended_suffix_links: boolean
+) => {
+  const lstrie = build_lstrie(text, show_suffix_links, show_extended_suffix_links, false);
+  const lscdawg = new LSCDAWG(lstrie);
+  return lscdawg;
+}
+
+const main = (text: string) => {
+  const lscdawg = build_lscdawg(text, false, false);
+  console.log(lscdawg.json);
+};
+
+if (require.main === module) {
+  main(process.argv.length === 3 ? process.argv[2] : "abaabac");
+}

--- a/src/lstrie.ts
+++ b/src/lstrie.ts
@@ -42,7 +42,7 @@ class Node {
   }
 }
 
-class StrTree {
+export class StrTree {
   root: Node;
   nodes: Array<Node>;
   slinks: Map<Node, Node>;

--- a/src/vis_lscdawg.ts
+++ b/src/vis_lscdawg.ts
@@ -1,0 +1,136 @@
+import { DataSet, Network } from "vis-network/standalone";
+import { build_lscdawg } from "./lscdawg";
+import * as visjs_default_options from "./visjs_default_options";
+
+const options = visjs_default_options.options;
+options.layout.hierarchical.direction = "LR";
+options.layout.hierarchical.levelSeparation = 255;
+options.layout.hierarchical.nodeSpacing = 205;
+options.layout.hierarchical.treeSpacing = 205;
+options.edges.smooth.type = "curvedCCW";
+
+const container = document.getElementById("network") as HTMLElement;
+const network = new Network(container, {}, options);
+let networkData = {};
+
+interface Params {
+  input_text: string;
+  show_suffix_links: boolean;
+  show_extended_suffix_links: boolean;
+}
+
+const load_params_from_url = () => {
+  const queryString = window.location.search;
+  // console.log('querystring', queryString)
+  const urlParams = new URLSearchParams(queryString);
+  let params: Params = {
+    input_text: "cocoa",
+    show_suffix_links: true,
+    show_extended_suffix_links: true,
+  };
+  const keys = ["input_text", "show_suffix_links", "implicit_cdawg"];
+  const undefined_values = ["", "true", "true"];
+  for (let key of keys) {
+    const urlkey = urlParams.get(key);
+  }
+
+  const urlkey = urlParams.get("input_text");
+  if (urlkey !== null) params.input_text = urlkey;
+  params.show_suffix_links = urlParams.get("show_suffix_links") === "true";
+  params.show_extended_suffix_links =
+    urlParams.get("show_extended_suffix_links") === "true";
+  return params;
+};
+
+const load_params_from_html = () => {
+  const input_text = (document.getElementById("input_text") as HTMLInputElement)
+    .value;
+  const show_suffix_links = (
+    document.getElementById("show_suffix_links") as HTMLInputElement
+  ).checked;
+  const show_extend_suffix_links = (
+    document.getElementById("show_extended_suffix_links") as HTMLInputElement
+  ).checked;
+  const params: Params = {
+    input_text: input_text,
+    show_suffix_links: show_suffix_links,
+    show_extended_suffix_links: show_extend_suffix_links
+  };
+  return params;
+};
+
+const set_params_to_url = (params: Params) => {
+  const url = new URL(window.location.toString());
+  for (let key of Object.keys(params)) {
+    url.searchParams.set(key, params[key as keyof Params].toString());
+  }
+  history.replaceState({}, "", url.toString());
+};
+
+const set_params_to_html = (params: Params) => {
+  const input_text = document.getElementById("input_text") as HTMLInputElement;
+  const show_suffix_links = document.getElementById(
+    "show_suffix_links"
+  ) as HTMLInputElement;
+  const show_extended_suffix_links = document.getElementById(
+    "show_extended_suffix_links"
+  ) as HTMLInputElement;
+  input_text.value = params.input_text;
+  show_suffix_links.checked = params.show_suffix_links;
+  show_extended_suffix_links.checked = params.show_extended_suffix_links;
+};
+
+const redraw = () => {
+  // load and set parameters
+  const params = load_params_from_html();
+  set_params_to_url(params);
+  console.log("params", params);
+
+  const lscdawg = build_lscdawg(
+    params.input_text,
+    params.show_suffix_links,
+    params.show_extended_suffix_links,
+  );
+  console.log(lscdawg);
+  const json = lscdawg.json;
+  console.log(json);
+  networkData = {
+    nodes: new DataSet(json.nodes),
+    edges: new DataSet(json.edges),
+  };
+  network.setData(networkData);
+};
+
+const main = () => {
+  // set event listener
+  const input_text = document.getElementById("input_text") as HTMLElement;
+  input_text.addEventListener("input", redraw);
+  input_text.addEventListener("propertychange", redraw);
+  const show_sl_btn = document.getElementById(
+    "show_suffix_links"
+  ) as HTMLElement;
+  show_sl_btn.addEventListener("change", redraw);
+  const show_esl_btn = document.getElementById(
+    "show_extended_suffix_links"
+  ) as HTMLElement;
+  show_esl_btn.addEventListener("change", redraw);
+
+  network.on("hoverEdge", function (e) {
+    console.log("hoverEdge", e);
+    // console.log('networkData.edges', networkData.edges.get(e.edge))
+    // @ts-ignore
+    networkData.edges.update({ id: e.edge, font: { size: 34 } });
+  });
+  network.on("blurEdge", function (e) {
+    console.log("blurEdge", e);
+    // @ts-ignore
+    networkData.edges.update({ id: e.edge, font: { size: 14 } });
+  });
+
+  // load and set parameters
+  const params = load_params_from_url();
+  set_params_to_html(params);
+
+  redraw();
+};
+main();


### PR DESCRIPTION
# Overview

I have added a linear-size CDAWG implementation.
The algorithm written in [src/lscdawg.ts](https://github.com/shibh308/visds/blob/add_linear_size_cdawg/src/lscdawg.ts) creates a linear-size CDAWG by merging isomorphic subtrees of the linear-size suffix trie.

# Example Image
![image](https://github.com/kg86/visds/assets/28044202/cf7dab84-b615-475b-8574-98c8ddd3e6ad)
