### PR TITLE
Add vis_lscdawg build entry

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = {
     vis_dag: "./src/vis_dag.ts",
     vis_dawg: "./src/vis_dawg.ts",
     vis_cdawg: "./src/vis_cdawg.ts",
+    vis_lscdawg: "./src/vis_lscdawg.ts",
     cdawg: "./src/cdawg.ts",
     vis_lstrie: "./src/vis_lstrie.ts",
     vis_sa: "./src/vis_sa.ts",


### PR DESCRIPTION
## Summary
- add vis_lscdawg entry to webpack config to generate vis_lscdawg.js
- aligns with vis_lscdawg.html which references the bundle

## Testing
- not run (config change only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `vis_lscdawg` entry to `webpack.config.js` to produce `vis_lscdawg.js` bundle.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6f990a29fbf3ad30bd3e7ec55e1f36d5f21a575. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->